### PR TITLE
Added Fix that adapts 'max' to windows resize

### DIFF
--- a/public/js/rp-public.js
+++ b/public/js/rp-public.js
@@ -53,6 +53,16 @@
 			value = $(window).scrollTop();
 			$('.readingProgressbar').attr('value', value);
 		});
+		// recalculer max lorsque la fenêtre est redimensionnée
+		$(window).on('resize', function(){
+			winHeight = $(window).height();
+			docHeight = $(document).height();
+			max = docHeight - winHeight;
+			$('.readingProgressbar').attr('max', max);
+
+			value =  $(window).scrollTop();
+			$('.readingProgressbar').attr('value', value);
+		});
 	});
 
 })( jQuery );


### PR DESCRIPTION
I noticed that the English wordpress installation of this plugin is slightly different. For example, that version has a "console.log(progressCustomPosition);" call that this js file does not.

In any case, this is the relevant line of code, to allow for 'max' to take into account browser resizes. Feel free to merge as you see fit.